### PR TITLE
Add *.pyc to .gitignore

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -127,6 +127,7 @@ Create a file named `.gitignore` in your `djangogirls` directory with the follow
     staticfiles
     local_settings.py
     db.sqlite3
+    *.pyc
 
 and save it. The dot on the beginning of the file name is important! As you can see, we're now telling Heroku to ignore `local_settings.py` and don't download it, so it's only available on your computer (locally).
 


### PR DESCRIPTION
In theory, this is not needed, since in Python 3, the pyc files are in **pycache**.

However, at the SF Django Girls event, several participants used Python 2, since
they had that already installed and it worked for the tutorial--up to this point, where
it broke in a hard-to-diagnose way. Their local_settings.pyc file was getting to
Heroku and it was trying to use local settings in deployment.

Adding *.pyc to .gitignore is harmless for people using Python 3, and solves this
problem for people using Python 2.
